### PR TITLE
ユーザー登録データ保存

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,4 +13,4 @@
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "modules/new_address";
-
+@import "modules/complete";

--- a/app/assets/stylesheets/modules/_complete.scss
+++ b/app/assets/stylesheets/modules/_complete.scss
@@ -1,0 +1,47 @@
+.Complete {
+  background-color: #f5f5f5;
+  width: 100%;
+  height: auto;
+  padding: 20px 0;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  &__box {
+    height: auto;
+    width: 700px;
+    background-color: white;
+  }
+  &__item {
+    height: 50px;
+    border-bottom: 1px solid whitesmoke;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+    &__title {
+      font-weight: bold;
+      font-size: 20px;
+    }
+  &__form {
+    font-size: 20px;
+    height: 200px;
+  }
+  &__form-set__create-creditcard{
+    margin-top: 50px;
+  }
+  &__form-set__create-creditcard-btn {
+    border: solid 2px #3CCACE;
+    color: white;
+    background-color: #3CCACE;
+    height: 40px;
+    width: 400px;
+  }
+  &__form-set__mypage-btn {
+    border: solid 2px #3CCACE;
+    color: white;
+    background-color: #3CCACE;
+    height: 40px;
+    width: 400px;
+  }
+}
+  

--- a/app/assets/stylesheets/modules/_new_address.scss
+++ b/app/assets/stylesheets/modules/_new_address.scss
@@ -33,20 +33,23 @@
     font-weight: 600;
   }
   span {
+    color:white;
+    border: solid 2px red;
     background-color: red;
-    color: white;
+    border-radius: 5px;
     font-weight: 600;
   }
   &__form-set__fullname {
     display: flex;
   }
   &__form-set__fullname-lastname {
-    width: 200px;
+    width: 195px;
     height: 40px;
     margin-bottom: 15px;
+    margin-right: 10px;
   }
   &__form-set__fullname-firstname {
-    width: 200px;
+    width: 195px;
     height: 40px;
     margin-bottom: 15px;
   }
@@ -57,16 +60,22 @@
     display: flex;
   }
   &__form-set__kanafull-lastname {
-    width: 200px;
+    width: 195px;
     height: 40px;
     margin-bottom: 15px;
+    margin-right: 10px;
   }
   &__form-set__kanafull-firstname {
-    width: 200px;
+    width: 195px;
     height: 40px;
     margin-bottom: 15px;
   }
   &__form-set__PostalCode-number {
+    width: 400px;
+    height: 40px;
+    margin-bottom: 15px;
+  }
+  &__form-set__Prefecture {
     width: 400px;
     height: 40px;
     margin-bottom: 15px;
@@ -89,9 +98,9 @@
     height: 40px;
     margin-bottom: 15px;
   }
-  &__form-set__room {
+  //&__form-set__room {
 
-  }
+  //}
   &__form-set__room-number {
     width: 400px;
     height: 40px;
@@ -109,7 +118,8 @@
 
   }
   &__form-set__user-register-btn {
-    background-color: red;
+    background-color: #3CCACE;  
+    border: solid 1px #3CCACE;
     color: white;
     font-weight: 800;
     width: 400px;
@@ -117,5 +127,11 @@
   }
   &__form-set__user-register-btn:hover {
     background-color: #dc143c;
+  }
+  .option {
+    color: white;
+    border: solid 2px #3CCACE;
+    background-color: #3CCACE;
+    border-radius: 5px;
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth
   before_action :basic_auth, if: :production?
   before_action :configure_permitted_parameters, if: :devise_controller?
-
+  before_action :authenticate_user!, except: [:index, :show] 
   private
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname,:family_name, :first_name, :family_name_kana, :first_name_kana, :birth_date])

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -87,4 +87,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
     session["devise.regist_data"]["user"].clear
     sign_in(:user, @user)
   end
+  
+  def complete
+  end
+  
+  private
+  def address_params
+    params.require(:address).permit(:address_first_name,:address_family_name,:address_first_name_kana,:address_family_name_kana,:post_code,:prefecture_id,:city,:address_line,:building_name,:phone_number)
+  end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,6 +4,6 @@ class Address < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
 
-  validates :address_first_name, :address_family_name, :address_first_name_kana, :address_family_name_kana, :post_code, :prefecture_id, :city, :address_line, :phone_number, presence: true
+  validates :address_first_name, :address_family_name, :address_first_name_kana, :address_family_name_kana, :post_code, :prefecture_id, :city, :address_line, :building_name, :phone_number, presence: true
 
-end 
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,36 @@ class User < ApplicationRecord
     presence: true
   validates :birth_date,
     presence: true
+  validates :address_family_name,
+    format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/},
+    presence: true
+  validates :address_first_name,
+    format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/},
+    presence: true
+  validates :address_family_name_kana,
+    format: { with: /\A[ァ-ヶー－]+\z/},
+    presence: true
+  validates :address_first_name_kana,
+    format: { with: /\A[ァ-ヶー－]+\z/},
+    presence: true
+  validates :post_code,
+    format: { with: /\A\d{3}\-?\d{4}\z/},
+    presence: true
+  validates :prefecture_id,
+    format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/},
+    presence: true
+  validates :city,
+    format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/},
+    presence: true 
+  validates :address_line,
+    format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/},
+    presence: true
+  validates :building_name,
+    format: { with: /\A([ぁ-んァ-ン一-龥]|ー)+\z/},
+    allow_blank: true
+  validates :phone_number,
+    format: { with: /\A\d{10}$|^\d{11}\z/},
+    allow_blank: true
   has_many :messages
   has_one :profile
   accepts_nested_attributes_for :profile

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -18,6 +18,9 @@
           = link_to "#", class: 'Header-part__contents__menu__left__list--second__btn' do
             ブランド
       %ul.Header-part__contents__menu__right
+      -if user_signed_in?
+        = link_to "マイページ", users_path
+      -else
         %li.Header-part__contents__menu__left__list--first
           = link_to "/users/sign_in", class: 'Header-part__contents__menu__left__list--first__btn' do
             ログイン

--- a/app/views/users/registrations/complete.html.haml
+++ b/app/views/users/registrations/complete.html.haml
@@ -1,0 +1,13 @@
+=render "shared/header"
+.Complete
+  .Complete__box
+    .Complete__item
+      .Complete__title
+        ユーザー登録が完了しました
+    .Complete__form
+      .Complete__form-set__create-creditcard
+        = link_to "クレジットカード登録", new_credit_card_path, class: "Complete__form-set__create-creditcard-btn"
+      .Complete__form-set__mypage
+        = link_to "マイページ", users_path, class: "Complete__form-set__mypage-btn"
+
+=render "shared/footer"

--- a/app/views/users/registrations/new_address.html.haml
+++ b/app/views/users/registrations/new_address.html.haml
@@ -1,3 +1,4 @@
+=render "shared/header"
 .Address
   .Address__box
     .Address__item
@@ -10,28 +11,33 @@
             お名前（全角）
             %span.Form-require 必須
           .Address__form-set__fullname
-            = f.text_field :lastname, class: "Address__form-set__fullname-lastname", placeholder: "例)山田"
-            = f.text_field :firstname, class: "Address__form-set__fullname-firstname", placeholder: "例)太郎"
+            = f.text_field :address_family_name, class: "Address__form-set__fullname-lastname", placeholder: "例)山田"
+            = f.text_field :address_first_name, class: "Address__form-set__fullname-firstname", placeholder: "例)太郎"
           .Address__form-set__Kana
             お名前カナ（全角）
             %span.Form-require 必須
           .Address__form-set__kanafull
-            = f.text_field :kana_lastname, class: "Address__form-set__kanafull-lastname", placeholder: "例)ヤマダ"
-            = f.text_field :kana_firstname, class: "Address__form-set__kanafull-firstname", placeholder: "例)タロウ"
+            = f.text_field :address_family_name_kana, class: "Address__form-set__kanafull-lastname", placeholder: "例)ヤマダ"
+            = f.text_field :address_first_name_kana, class: "Address__form-set__kanafull-firstname", placeholder: "例)タロウ"
           .Address__form-set__PostalCode
             %span.Form-require 必須
-          = f.text_field :PostalCode, class: "Address__form-set__PostalCode-number", placeholder: "都道府県"
+          = f.text_field :post_code, class: "Address__form-set__PostalCode-number", placeholder: "郵便番号　※ハイフン不要"
+          .Address__form-set__Prefecture_id
+            %span.Form-require 必須
+          = f.text_field :prefecture_id, class: "Address__form-set__Prefecture", placeholder: "都道府県"
           .Address__form-set__municipality
             %span.Form-require 必須
-          = f.text_field :municipality, class: "Address__form-set__municipality-name", placeholder: "市区町村"
+          = f.text_field :city, class: "Address__form-set__municipality-name", placeholder: "市区町村"
           .Address__form-set__houseNumber
             %span.Form-require 必須
-          = f.text_field :housenumber, class: "Address__form-set__houseNumber-math",placeholder: "番地"
+          = f.text_field :address_line, class: "Address__form-set__houseNumber-math",placeholder: "○丁目○番地○"
           .Address__form-set__apartment
-            = f.text_field :apartment, class: "Address__form-set__apartment-name", placeholder: "マンション名やビル名"
-          .Address__form-set__room
-          = f.text_field :room, class: "Address__form-set__room-number", placeholder: "部屋番号"
+            = f.text_field :building_name, class: "Address__form-set__apartment-name", placeholder: "○マンション/○ビル○号室"
+          //.Address__form-set__room
+          //= f.text_field :room, class: "Address__form-set__room-number", placeholder: "部屋番号"
           .Address__form-set__phone
-          = f.text_field :phone, class: "Address__form-set__phone-number", placeholder: "電話番号"
+            %span.Form-require.option 任意
+          = f.text_field :phone_number, class: "Address__form-set__phone-number", placeholder: "電話番号"
           .Address__form-set__user-register
           = f.submit "ユーザー登録", class: "Address__form-set__user-register-btn"
+=render "shared/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,10 @@ Rails.application.routes.draw do
     post 'addresses', to: 'users/registrations#create_address'
   end
 
+  devise_scope :user do
+    get "complete", :to => "users/registrations#complete"
+  end
+
   root 'items#index'
   resources :credit_cards, only: [:index, :new, :create, :show] 
   resources :logouts, only: [:index]

--- a/db/migrate/20201025150143_create_addresses.rb
+++ b/db/migrate/20201025150143_create_addresses.rb
@@ -2,13 +2,13 @@ class CreateAddresses < ActiveRecord::Migration[6.0]
   def change
     create_table :addresses do |t|
       t.references :user, null: false, foreign_key: true
-      t.string :address_first_name, null: false
       t.string :address_family_name, null: false
-      t.string :address_first_name_kana, null: false
+      t.string :address_first_name, null: false
       t.string :address_family_name_kana, null: false
+      t.string :address_first_name_kana, null: false
       t.string :post_code, null: false
       t.string :prefecture_id, null:false
-      t.date :city, null: false
+      t.string :city, null: false
       t.string :address_line, null: false
       t.string :building_name
       t.integer :phone_number, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_25_150143) do
+ActiveRecord::Schema.define(version: 2020_10_30_114431) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "address_first_name", null: false
     t.string "address_family_name", null: false
-    t.string "address_first_name_kana", null: false
+    t.string "address_first_name", null: false
     t.string "address_family_name_kana", null: false
+    t.string "address_first_name_kana", null: false
     t.string "post_code", null: false
     t.string "prefecture_id", null: false
-    t.date "city", null: false
+    t.string "city", null: false
     t.string "address_line", null: false
     t.string "building_name"
     t.integer "phone_number", null: false
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define(version: 2020_10_25_150143) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
-ActiveRecord::Schema.define(version: 2020_10_30_114431) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -54,15 +53,6 @@ ActiveRecord::Schema.define(version: 2020_10_30_114431) do
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id"
-    t.string "item_name", null: false
-    t.text "item_description", null: false
-    t.integer "category_id", null: false
-    t.integer "conditon_id", null: false
-    t.integer "shopping_charges_id", null: false
-    t.integer "prefecture_id", null: false
-    t.integer "days_to_delivery_id", null: false
-    t.integer "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,4 +11,17 @@ FactoryBot.define do
     first_name_kana       {"タロウ"}
     birth_date             {"2000-01-01"}
   end
+  
+  factory :address do
+    address_family_name   {"山田"}
+    address_first_name    {"太郎"}
+    address_family_name_kana  {"ヤマダ"}
+    address_first_name_kana   {"タロウ"}
+    post_code             {"000-0000"}
+    prefecture_id         {"東京都"}
+    city                  {"渋谷区"}
+    address_line          {"1-1-1"}
+    building_name         {"一ビル"}
+    phone_number          {"0000000000"}
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 describe User do
   describe '#create' do
-     #user = User.new(nickname: "", email: "kkk@gmail.com", password: "00000000", password_confirmation: "00000000")
-     #user.valid?
-     #expect(user.errors.full_messages).to include("Nicknameを入力してください")
+
     it "全ての項目の入力が存在すれば登録できること" do
       user = build(:user)
       expect(user).to be_valid
@@ -120,6 +118,73 @@ describe User do
       user = build(:user, first_name_kana: "あいうえお")
       user.valid?
       expect(user.errors[:first_name_kana]).to include("は不正な値です")
+    end
+  end
+end
+
+describe Address do
+  describe '#create' do
+ 
+    # 1
+    it "address_family_nameがない場合は登録できないこと" do
+      address = build(:address, address_family_name: nil)
+      address.valid?
+      expect(address.errors[:address_family_name]).to include("を入力してください")
+    end
+ 
+    # 2
+    it "address_first_nameがない場合は登録できないこと" do
+      address = build(:address, address_first_name: nil)
+      address.valid?
+      expect(address.errors[:address_first_name]).to include("を入力してください")
+    end
+ 
+    # 3
+    it "address_family_name_kanaがない場合は登録できないこと" do
+      address = build(:address, address_family_name_kana: nil)
+      address.valid?
+      expect(address.errors[:address_family_name_kana]).to include("を入力してください")
+    end
+ 
+    # 4
+    it "address_first_name_kanaがない場合は登録できないこと" do
+      address = build(:address, address_first_name_kana: nil)
+      address.valid?
+      expect(address.errors[:address_first_name_kana]).to include("を入力してください")
+    end
+ 
+    # 5
+    it "post_codeがない場合は登録できないこと" do
+      address = build(:address, post_code: nil)
+      address.valid?
+      expect(address.errors[:post_code]).to include("を入力してください")
+    end
+ 
+    # 6
+    it "prefecture_idがない場合は登録できないこと" do
+      address = build(:address, prefecture_id: nil)
+      address.valid?
+      expect(address.errors[:prefecture_id]).to include("を入力してください")
+    end
+ 
+    # 7
+    it "cityがない場合は登録できないこと" do
+      address = build(:address, city: nil)
+      address.valid?
+      expect(address.errors[:city]).to include("を入力してください")
+    end
+ 
+    # 8
+    it "address_lineがない場合は登録できないこと" do
+      address = build(:address, address_line: nil)
+      address.valid?
+      expect(address.errors[:address_line]).to include("を入力してください")
+    end
+ 
+    # 9
+    it "address_family_name、address_first_name、address_family_name_kana、address_first_name_kana、post_code、prefecture_id、city、address_line全てが存在すれば登録できること" do
+      address = build(:address)
+      expect(address).to be_valid
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,9 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
+  config.before(:all) do
+    FactoryBot.reload
+  end
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods


### PR DESCRIPTION
what
フリマアプリの利用者のデータがちゃんと保存されるか

why
フリマアプリを利用するにあたり、どの利用者か登録する必要があるため

今回、分業のためトレロ上の①「ユーザー情報・本人確認情報」と②「商品送付先住所情報」それぞれ、
データ保存まで、LGTMをもらったが、①「ユーザー情報・本人確認情報」をマージさせた際に、
②「商品送付先住所情報」のデータが保存されなくなってしまったので、
そこの部分コメントレビュー（ＬＧＴＭ）をいただけないでしょうか。
よろしくお願いいたします。